### PR TITLE
Add macOS support to file.c

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -35,7 +35,7 @@
    #include <sys/stat.h>
 #endif
 
-#ifdef ALLEGRO_UNIX
+#if defined (ALLEGRO_UNIX) || defined (ALLEGRO_MACOSX)
    #include <pwd.h>                 /* for tilde expansion */
 #endif
 
@@ -174,7 +174,7 @@ char *canonicalize_filename(char *dest, AL_CONST char *filename, int size)
 
    #endif
 
-   #ifdef ALLEGRO_UNIX
+   #if defined (ALLEGRO_UNIX) || defined (ALLEGRO_MACOSX)
 
       /* if the filename starts with ~ then it's relative to a home directory */
       if ((ugetc(filename) == '~')) {
@@ -256,7 +256,7 @@ char *canonicalize_filename(char *dest, AL_CONST char *filename, int size)
       pos = ustrsize(buf);
    }
 
- #ifdef ALLEGRO_UNIX
+ #if defined (ALLEGRO_UNIX) || defined (ALLEGRO_MACOSX)
    no_relativisation:
  #endif
 


### PR DESCRIPTION
In order to modify paths correctly in macOS, it needs to operate the same way as Unix, therefore I updated the file.c file to apply the unix changes.