### PR TITLE
adding a build to linux .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - build-essential
+    - pkg-config 
+    - cmake 
+    - libsdl2-2.0 
+    - libsdl2-dev 
+    - libfreetype6-dev 
+    - libogg-dev 
+    - libtheora-dev 
+    - libvorbis-dev
+    - liballegro4-dev
+    - libaldmb1-dev
+script:
+- mkdir build-sdl2
+- cd build-sdl2
+- cmake -D SHARED=off -DCMAKE_BUILD_TYPE=Debug ..
+- make


### PR DESCRIPTION
this is just a .travis.yml so it's possible to check the allegro library is building on Linux. Travis-CI also support MacOS builds, but I am not adding it here yet. You still need to enable it on Travis-CI. As is, it's failing in some lines, needing `-std=c99` being passed somewhere.

    allegro/src/sdl2/system.c:603:7: 
      error: ‘for’ loop initial declarations are only allowed in C99 mode
      for (int i = 0; i < rinfo.num_texture_formats; i++) {
      ^